### PR TITLE
fix: disable google search grounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to this project will be documented in this file.
 - UI: widened model dropdown for readability; modernized file chooser button; display a rough token estimate (size/4) after upload.
 - Docs: linked `CHANGELOG.md` from README and added Pages deployment instructions.
 - CI: added GitHub Actions workflow to publish to GitHub Pages on push to `main`.
+- Fix: explicitly send empty `tools` array in Gemini requests to avoid Google Search grounding.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A tiny client‑side app that uploads a book (PDF/EPUB) and iteratively distills
 - Keep your Gemini API key in the UI field; it’s stored in `localStorage` only on your machine.
 - Model, prompt, and generation temperature persist in `localStorage` as well.
 - External libs (Petite‑Vue, @google/genai, marked, jsPDF) are loaded from CDNs.
+- Requests explicitly omit search tools so Gemini responds without Google Search grounding.
 
 ## Troubleshooting
 

--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ createApp({
     // First turn
     const filePart = createPartFromUri(this.uploadedFile.uri, this.uploadedFile.mimeType);
     const userFirst = createUserContent([ filePart, 'Begin as instructed: include Opening the Journey (intro, architecture, reading guide) and the first complete thematic section.' ]);
-    const req1 = { model: this.model, contents:[ userFirst ], config: this.makeConfig() };
+    const req1 = { model: this.model, contents:[ userFirst ], tools: [], config: this.makeConfig() };
     const [resp1, r1tries, r1err] = await this.gem.callWithRetries(req1);
     if(r1err){ if(String(r1err?.message)==='__aborted__') return; this.finishWithError(r1err, req1, r1tries); return; }
     const text1 = resp1?.text || this.gem.extractText(resp1);
@@ -148,7 +148,7 @@ createApp({
 
       const filePart = createPartFromUri(this.uploadedFile.uri, this.uploadedFile.mimeType);
       const nextUser = createUserContent([ filePart, 'Next' ]);
-      const req = { model:this.model, contents:[...this.history, nextUser], config: this.makeConfig() };
+      const req = { model:this.model, contents:[...this.history, nextUser], tools: [], config: this.makeConfig() };
       const [resp, tries, err] = await this.gem.callWithRetries(req);
       if(err){
         if(String(err?.message)==='__aborted__') return;


### PR DESCRIPTION
## Summary
- explicitly send empty tools array so Gemini won't invoke Google Search grounding
- document disabled search grounding in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49bd29328832ba1ae5617cb8e0ec3