### PR TITLE
Add Gemini 3 Pro model option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- feat: include the `gemini-3-pro-preview` model option in the UI and docs.
+
 ### Fixed
 - fix: auto wait 60s now includes time taken by previous request (starts counting from when request begins, not when it ends)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See `docs/WORKFLOW.md` for the authoritative description of the request flow, re
   - Step 3 — upload your book (PDF/EPUB)
   - Step 4 — edit the prompt
   - Advanced (collapsed): temperature (enabled by default at 1.0), end marker, budgets, anomaly pause toggle, optional 60s auto-wait between requests
+- Supported models: `gemini-3-pro-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
 
 ## Export
 

--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ createApp({
   autoWaiting: false, autoWaitRemainingMs: 0, autoWaitPlannedMs: 0,
   lastErrorMessage: '',
 
-  model: (()=>{ const allowed=['gemini-2.5-pro','gemini-2.5-flash','gemini-2.5-flash-lite']; const saved=localStorage.getItem('distillboard.model'); return allowed.includes(saved)?saved:'gemini-2.5-pro'; })(),
+  model: (()=>{ const allowed=['gemini-3-pro-preview','gemini-2.5-pro','gemini-2.5-flash','gemini-2.5-flash-lite']; const saved=localStorage.getItem('distillboard.model'); return allowed.includes(saved)?saved:'gemini-2.5-pro'; })(),
   useTemperature: (()=>{ const v=localStorage.getItem('distillboard.useTemperature'); return (v===null)? true : (v==='true'); })(),
   temperature: +(localStorage.getItem('distillboard.temperature')||'1.0'),
   themeMode: (()=>{ const v=localStorage.getItem('distillboard.themeMode'); if(v==='light'||v==='dark'||v==='auto') return v; const legacy=localStorage.getItem('distillboard.dark'); if(legacy!==null) return legacy==='true'?'dark':'light'; return 'auto'; })(),

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -5,7 +5,7 @@ This document is the authoritative description of how the app orchestrates Gemin
 ## Overview
 
 - Frontend stack: Petite‑Vue app (`app.js`) + a thin Gemini service wrapper (`gemini.js`).
-- Models: `gemini-2.5-pro` (default), `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
+- Models: `gemini-3-pro-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
 - The app uploads a book file (PDF/EPUB), then iterates sections by sending a first turn with the file and subsequent turns with only `"Next"`.
 
 ## Setup

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
           <div style="flex:2; min-width:280px">
             <label style="margin-top:0">Model</label>
             <select v-model="model" style="width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--line);background:var(--surface);color:var(--fg);min-width:100%">
+              <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
               <option value="gemini-2.5-pro">gemini-2.5-pro</option>
               <option value="gemini-2.5-flash">gemini-2.5-flash</option>
               <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>


### PR DESCRIPTION
## Summary
- add the gemini-3-pro-preview option to the model selector and allow list so it can be chosen in the UI
- document the newly supported model in README and docs/WORKFLOW.md and note the change in the changelog

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc0af1788832b8f2ce2fec27998db)