### PR TITLE
feat: add gemini-3-flash-preview model option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - feat: include the `gemini-3-pro-preview` model option in the UI and docs.
+- feat: add the `gemini-3-flash-preview` model option alongside other Gemini choices.
 
 ### Fixed
 - fix: auto wait 60s now includes time taken by previous request (starts counting from when request begins, not when it ends)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See `docs/WORKFLOW.md` for the authoritative description of the request flow, re
   - Step 3 — upload your book (PDF/EPUB)
   - Step 4 — edit the prompt
   - Advanced (collapsed): temperature (enabled by default at 1.0), end marker, budgets, anomaly pause toggle, optional 60s auto-wait between requests
-- Supported models: `gemini-3-pro-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
+- Supported models: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
 
 ## Export
 

--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ createApp({
   autoWaiting: false, autoWaitRemainingMs: 0, autoWaitPlannedMs: 0,
   lastErrorMessage: '',
 
-  model: (() => { const allowed = ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite']; const saved = localStorage.getItem('distillboard.model'); return allowed.includes(saved) ? saved : 'gemini-2.5-pro'; })(),
+  model: (() => { const allowed = ['gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite']; const saved = localStorage.getItem('distillboard.model'); return allowed.includes(saved) ? saved : 'gemini-2.5-pro'; })(),
   useTemperature: (() => { const v = localStorage.getItem('distillboard.useTemperature'); return (v === null) ? true : (v === 'true'); })(),
   temperature: +(localStorage.getItem('distillboard.temperature') || '1.0'),
   themeMode: (() => { const v = localStorage.getItem('distillboard.themeMode'); if (v === 'light' || v === 'dark' || v === 'auto') return v; const legacy = localStorage.getItem('distillboard.dark'); if (legacy !== null) return legacy === 'true' ? 'dark' : 'light'; return 'auto'; })(),

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -5,7 +5,7 @@ This document is the authoritative description of how the app orchestrates Gemin
 ## Overview
 
 - Frontend stack: Petite‑Vue app (`app.js`) + a thin Gemini service wrapper (`gemini.js`).
-- Models: `gemini-3-pro-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
+- Models: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
 - The app uploads a book file (PDF/EPUB), then iterates sections by sending a first turn with the file and subsequent turns with only `"Next"`.
 
 ## Setup

--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
             <label>Model</label>
             <select v-model="model">
               <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
+              <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
               <option value="gemini-2.5-pro">gemini-2.5-pro</option>
               <option value="gemini-2.5-flash">gemini-2.5-flash</option>
               <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -111,6 +111,8 @@ function confirmSaveKey() {
 
           <label>Model</label>
           <select :value="model" @change="$emit('update:model', $event.target.value)">
+            <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
+            <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
             <option value="gemini-2.5-pro">gemini-2.5-pro</option>
             <option value="gemini-2.5-flash">gemini-2.5-flash</option>
             <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>


### PR DESCRIPTION
### Motivation
- Add support for the newer Gemini 3 Flash model so users can select it from the UI model dropdown. 
- Keep persisted model whitelist in sync so saved model selections remain valid. 
- Align the model name with the preview naming convention observed for other Gemini preview models. 
- Document the new model option for users and changelog visibility.

### Description
- Add `gemini-3-flash-preview` option to the main UI dropdown in `index.html` and to the Settings component in `src/components/Settings.vue` by adding the new `<option>` entry. 
- Whitelist `gemini-3-flash-preview` in the allowed model list used for persisted state in `app.js`. 
- Update user-facing documentation in `README.md` and `docs/WORKFLOW.md` to list the new model, and note the change in `CHANGELOG.md`. 
- Rename earlier tentative entries to the `-preview` variant after attempting to verify the official naming pattern.

### Testing
- Ran a production build via `npm run build`, which failed due to a missing dev dependency `@vitejs/plugin-vue` referenced by `vite.config.js`. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173`, which also failed for the same missing plugin. 
- No unit tests were changed; existing test suite was not executed as part of this PR. 
- The code changes were committed and are visible in the repo, but build/dev errors need the missing dev dependency added before successful automated builds can run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694902b454a4832b86e5a343cc21e54d)