### PR TITLE
fix: use gemini-3.1-pro-preview model id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- feat: add `gemini-3.1-pro-preview` as a selectable model in settings (Vue + legacy UI) and model validation.
 - feat: include the `gemini-3-pro-preview` model option in the UI and docs.
 - feat: add the `gemini-3-flash-preview` model option alongside other Gemini choices.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See `docs/WORKFLOW.md` for the authoritative description of the request flow, re
   - Step 3 — upload your book (PDF/EPUB)
   - Step 4 — edit the prompt
   - Advanced (collapsed): temperature (enabled by default at 1.0), end marker, budgets, anomaly pause toggle, optional 60s auto-wait between requests
-- Supported models: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
+- Supported models: `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro` (default), `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
 
 ## Export
 

--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ createApp({
   autoWaiting: false, autoWaitRemainingMs: 0, autoWaitPlannedMs: 0,
   lastErrorMessage: '',
 
-  model: (() => { const allowed = ['gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite']; const saved = localStorage.getItem('distillboard.model'); return allowed.includes(saved) ? saved : 'gemini-2.5-pro'; })(),
+  model: (() => { const allowed = ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite']; const saved = localStorage.getItem('distillboard.model'); return allowed.includes(saved) ? saved : 'gemini-2.5-pro'; })(),
   useTemperature: (() => { const v = localStorage.getItem('distillboard.useTemperature'); return (v === null) ? true : (v === 'true'); })(),
   temperature: +(localStorage.getItem('distillboard.temperature') || '1.0'),
   themeMode: (() => { const v = localStorage.getItem('distillboard.themeMode'); if (v === 'light' || v === 'dark' || v === 'auto') return v; const legacy = localStorage.getItem('distillboard.dark'); if (legacy !== null) return legacy === 'true' ? 'dark' : 'light'; return 'auto'; })(),

--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@
 
             <label>Model</label>
             <select v-model="model">
+              <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
               <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
               <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
               <option value="gemini-2.5-pro">gemini-2.5-pro</option>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import TraceDrawer from './components/TraceDrawer.vue'
 // Constants
 const DEFAULT_PROMPT = `# Book Deep-Dive Exploration Prompt\n\n**Your Mission:** You are tasked with creating an immersive, in-depth exploration of a book I provide. Your goal is to channel the author's voice and produce a series of thematic deep-dives that, when combined, will read as a single, flowing document—like an extended meditation on the book written by the author themselves.\n\n## For the First Response Only\n\n**Structure your first response in two parts:**\n\n### Part 1: Opening the Journey\n- **Book Introduction**: In the author's voice, introduce the book's core premise and why it was written\n- **The Architecture**: Present a roadmap of all major themes/sections that will be covered across our multi-turn exploration, showing how each builds upon the last\n- **Reading Guide**: Briefly explain how these sections work together to form the complete journey\n\n### Part 2: First Thematic Section\n- Proceed with the first major theme following the standard section structure below\n\n## For All Thematic Sections\n\n**Creating Each Section:**\nBegin each section with a **thematic title** that captures the essence of what you're exploring.\n\n## Our Process\n- I'll provide the book source\n- You'll create the first response with both the opening journey overview and the first thematic section\n- When I respond with "Next", identify the next logical theme and create another complete section\n- Each new section should begin in a way that flows naturally from the previous section\n- When you've covered all major themes and the book's journey is complete, respond only with: \`<end_of_book>\`\n\n## Key Principles\n- **The reader should feel they've read the book itself through your responses**\n- Privilege completeness and depth over conciseness\n- Think of the final combined document as the book's essence, distilled but not diluted\n\n## Remember\nYou're not summarizing or studying the book—you're presenting it in its full richness through the author's own eyes. The reader should finish feeling like they've genuinely experienced the book's complete content, receiving all its wisdom, stories, and insights directly from the source material itself.`
 const AUTO_WAIT_MS = 60000
+const ALLOWED_MODELS = ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite']
 
 // State
 const apiKey = ref(localStorage.getItem('distillboard.gemini_key') || '')
@@ -46,7 +47,10 @@ const autoWaitPlannedMs = ref(0)
 
 // Settings
 const savedKeys = ref(JSON.parse(localStorage.getItem('distillboard.saved_keys') || '[]'))
-const model = ref(localStorage.getItem('distillboard.model') || 'gemini-2.5-pro')
+const model = ref((() => {
+  const saved = localStorage.getItem('distillboard.model')
+  return ALLOWED_MODELS.includes(saved) ? saved : 'gemini-2.5-pro'
+})())
 const useTemperature = ref(localStorage.getItem('distillboard.useTemperature') === 'true')
 const temperature = ref(+(localStorage.getItem('distillboard.temperature') || '1.0'))
 const themeMode = ref(localStorage.getItem('distillboard.themeMode') || 'auto')

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -111,6 +111,7 @@ function confirmSaveKey() {
 
           <label>Model</label>
           <select :value="model" @change="$emit('update:model', $event.target.value)">
+            <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
             <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
             <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
             <option value="gemini-2.5-pro">gemini-2.5-pro</option>


### PR DESCRIPTION
### Motivation
- Correct an incorrect model identifier so the UI, persisted settings validation, and docs use the required model string `gemini-3.1-pro-preview` consistently.

### Description
- Replaced `gemini-3.1-pro` with `gemini-3.1-pro-preview` in the Vue settings UI (`src/components/Settings.vue`) and legacy static UI (`index.html`).
- Updated the allowed-model lists and model initialization/validation in the Vue app (`src/App.vue`) and legacy app (`app.js`) to include `gemini-3.1-pro-preview` and preserve the existing fallback to `gemini-2.5-pro`.
- Updated documentation references in `README.md` and the unreleased note in `CHANGELOG.md` to list `gemini-3.1-pro-preview`.

### Testing
- Ran `npm run build`, which failed in this environment due to a missing dev dependency (`@vitejs/plugin-vue`) and is an environment artifact (failed).
- Served the static site with `python -m http.server 8000` and verified the updated option appears in the legacy UI by capturing a Playwright screenshot (screenshot capture succeeded).
- No existing unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69997ecd1110832bb68e770ce84bed2d)